### PR TITLE
FAO mobile village census flow

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,1 +1,2 @@
 const languageKey = "language";
+const selectedVillageIdKey = "selectedVillageId";

--- a/lib/locator.dart
+++ b/lib/locator.dart
@@ -5,6 +5,7 @@ import 'package:get_it/get_it.dart';
 import 'package:logger/logger.dart';
 import 'package:podd_app/constants.dart';
 import 'package:podd_app/services/api/auth_api.dart';
+import 'package:podd_app/services/api/census_api.dart';
 import 'package:podd_app/services/api/comment_api.dart';
 import 'package:podd_app/services/api/configuration_api.dart';
 import 'package:podd_app/services/api/file_api.dart';
@@ -17,6 +18,7 @@ import 'package:podd_app/services/api/register_api.dart';
 import 'package:podd_app/services/api/report_api.dart';
 import 'package:podd_app/services/api/report_type_api.dart';
 import 'package:podd_app/services/auth_service.dart';
+import 'package:podd_app/services/census_service.dart';
 import 'package:podd_app/services/comment_service.dart';
 import 'package:podd_app/services/config_service.dart';
 import 'package:podd_app/services/db_service.dart';
@@ -252,6 +254,16 @@ StreamController<String> setupLocator(String environment) {
     ForgotPasswordApi,
   ]);
 
+  if (locator.isRegistered<ICensusService>()) {
+    locator.unregister<ICensusService>();
+  }
+  locator.registerSingletonAsync<ICensusService>(() async {
+    controller.add("init census service");
+    return CensusService();
+  }, dependsOn: [
+    CensusApi,
+  ]);
+
   if (locator.isRegistered<IProfileService>()) {
     locator.unregister<IProfileService>();
   }
@@ -331,6 +343,15 @@ registerApiLocators(StreamController<String> controller) {
     var gqlService = locator<GqlService>();
     controller.add("init profile api");
     return ProfileApi(gqlService.resolveClientFunction);
+  }, dependsOn: [GqlService]);
+
+  if (locator.isRegistered<CensusApi>()) {
+    locator.unregister<CensusApi>();
+  }
+  locator.registerSingletonAsync<CensusApi>(() async {
+    var gqlService = locator<GqlService>();
+    controller.add("init census api");
+    return CensusApi(gqlService.resolveClientFunction);
   }, dependsOn: [GqlService]);
 
   if (locator.isRegistered<ReportTypeApi>()) {

--- a/lib/models/animal_species.dart
+++ b/lib/models/animal_species.dart
@@ -1,0 +1,30 @@
+class AnimalSpecies {
+  final int id;
+  final String code;
+  final String name;
+  final bool active;
+  final int sortOrder;
+
+  const AnimalSpecies({
+    required this.id,
+    required this.code,
+    required this.name,
+    this.active = true,
+    this.sortOrder = 0,
+  });
+
+  factory AnimalSpecies.fromJson(Map<String, dynamic> json) => AnimalSpecies(
+        id: json['id'] is int ? json['id'] as int : int.parse('${json['id']}'),
+        code: json['code']?.toString() ?? '',
+        name: json['name']?.toString() ?? '',
+        active: json['active'] as bool? ?? true,
+        sortOrder: json['sortOrder'] as int? ?? 0,
+      );
+
+  String get displayName {
+    if (code.isEmpty) {
+      return name;
+    }
+    return '$code - $name';
+  }
+}

--- a/lib/models/inviation_code_result.dart
+++ b/lib/models/inviation_code_result.dart
@@ -1,4 +1,5 @@
 import 'package:podd_app/models/operation_exception_failure.dart';
+import 'package:podd_app/models/village.dart';
 
 class InvitationCodeResult {}
 
@@ -6,9 +7,17 @@ class InvitationCodeSuccess extends InvitationCodeResult {
   String authorityName;
   String? generatedUsername;
   String? generatedEmail;
+  List<Village> villages;
 
   InvitationCodeSuccess(
-      this.authorityName, this.generatedUsername, this.generatedEmail);
+    this.authorityName,
+    this.generatedUsername,
+    this.generatedEmail, [
+    this.villages = const [],
+  ]);
+
+  String get villageNames =>
+      villages.map((village) => village.displayName).join(', ');
 }
 
 class InvitationCodeFailure extends OperationExceptionFailure

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,3 +1,5 @@
+import 'package:podd_app/models/village.dart';
+
 class UserProfile {
   int id;
   String username;
@@ -10,6 +12,7 @@ class UserProfile {
   String? role;
   bool? consent;
   List<String> features;
+  List<Village> assignedVillages;
   String? avatarUrl;
   String? address;
 
@@ -25,6 +28,7 @@ class UserProfile {
     this.role,
     this.consent,
     this.features = const [],
+    this.assignedVillages = const [],
     this.avatarUrl,
     this.address,
   });
@@ -40,7 +44,12 @@ class UserProfile {
         telephone: json['telephone']?.toString(),
         role: json['role']?.toString(),
         consent: json['consent'] ?? false,
-        features: (json['features'] as List).cast<String>(),
+        features: (json['features'] as List? ?? const [])
+            .map((feature) => feature.toString())
+            .toList(),
+        assignedVillages: (json['assignedVillages'] as List? ?? const [])
+            .map((village) => Village.fromJson(village))
+            .toList(),
         avatarUrl: json['avatarUrl']?.toString(),
         address: json['address']?.toString(),
       );
@@ -58,6 +67,8 @@ class UserProfile {
       'role': role,
       'consent': consent,
       'features': features,
+      'assignedVillages':
+          assignedVillages.map((village) => village.toJson()).toList(),
       'avatarUrl': avatarUrl,
       'address': address,
     };
@@ -65,4 +76,12 @@ class UserProfile {
 
   bool hasFeatureEnabled(String name) =>
       features.indexWhere((feature) => feature == "features.$name") != -1;
+
+  bool get hasAssignedVillages => assignedVillages.isNotEmpty;
+
+  Village? get primaryAssignedVillage =>
+      assignedVillages.isEmpty ? null : assignedVillages.first;
+
+  String get assignedVillageNames =>
+      assignedVillages.map((village) => village.displayName).join(', ');
 }

--- a/lib/models/village.dart
+++ b/lib/models/village.dart
@@ -1,0 +1,32 @@
+class Village {
+  final int id;
+  final String code;
+  final String name;
+
+  const Village({
+    required this.id,
+    required this.code,
+    required this.name,
+  });
+
+  factory Village.fromJson(Map<String, dynamic> json) => Village(
+        id: json['id'] is int ? json['id'] as int : int.parse('${json['id']}'),
+        code: json['code']?.toString() ?? '',
+        name: json['name']?.toString() ?? '',
+      );
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'code': code,
+      'name': name,
+    };
+  }
+
+  String get displayName {
+    if (code.isEmpty) {
+      return name;
+    }
+    return '$code - $name';
+  }
+}

--- a/lib/models/village_census.dart
+++ b/lib/models/village_census.dart
@@ -1,0 +1,91 @@
+import 'package:podd_app/models/animal_species.dart';
+import 'package:podd_app/models/operation_exception_failure.dart';
+import 'package:podd_app/models/village.dart';
+
+class AnimalCensusFactInput {
+  final int speciesId;
+  final int animalQuantity;
+  final int householdQuantity;
+
+  const AnimalCensusFactInput({
+    required this.speciesId,
+    required this.animalQuantity,
+    required this.householdQuantity,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'speciesId': speciesId,
+      'animalQuantity': animalQuantity,
+      'householdQuantity': householdQuantity,
+    };
+  }
+}
+
+class AnimalCensusFact {
+  final AnimalSpecies species;
+  final int animalQuantity;
+  final int householdQuantity;
+
+  const AnimalCensusFact({
+    required this.species,
+    required this.animalQuantity,
+    required this.householdQuantity,
+  });
+
+  factory AnimalCensusFact.fromJson(Map<String, dynamic> json) =>
+      AnimalCensusFact(
+        species: AnimalSpecies.fromJson(json['species']),
+        animalQuantity: json['animalQuantity'] as int? ?? 0,
+        householdQuantity: json['householdQuantity'] as int? ?? 0,
+      );
+}
+
+class VillageCensusSnapshot {
+  final int id;
+  final Village? village;
+  final DateTime? censusDate;
+  final String? submittedAt;
+  final List<AnimalCensusFact> facts;
+
+  const VillageCensusSnapshot({
+    required this.id,
+    this.village,
+    this.censusDate,
+    this.submittedAt,
+    this.facts = const [],
+  });
+
+  factory VillageCensusSnapshot.fromJson(Map<String, dynamic> json) =>
+      VillageCensusSnapshot(
+        id: json['id'] is int ? json['id'] as int : int.parse('${json['id']}'),
+        village:
+            json['village'] != null ? Village.fromJson(json['village']) : null,
+        censusDate: json['censusDate'] != null
+            ? DateTime.tryParse(json['censusDate'].toString())
+            : null,
+        submittedAt: json['submittedAt']?.toString(),
+        facts: (json['facts'] as List? ?? const [])
+            .map((fact) => AnimalCensusFact.fromJson(fact))
+            .toList(),
+      );
+}
+
+abstract class VillageCensusSubmitResult {}
+
+class VillageCensusSubmitSuccess extends VillageCensusSubmitResult {
+  final VillageCensusSnapshot snapshot;
+
+  VillageCensusSubmitSuccess(this.snapshot);
+}
+
+class VillageCensusSubmitFailure extends OperationExceptionFailure
+    implements VillageCensusSubmitResult {
+  VillageCensusSubmitFailure(super.e);
+}
+
+class VillageCensusSubmitValidationFailure extends VillageCensusSubmitResult {
+  final List<String> messages;
+
+  VillageCensusSubmitValidationFailure(this.messages);
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
 import 'package:podd_app/services/auth_service.dart';
+import 'package:podd_app/ui/census/census_view.dart';
 import 'package:podd_app/ui/home/home_view.dart';
 import 'package:podd_app/ui/home/observation/observation_home_view.dart';
 import 'package:podd_app/ui/home/report_home_view.dart';
@@ -34,6 +35,7 @@ class OhtkRouter {
   static const observationSubjectDetail = 'observationSubjectDetail';
   static const observationMonitoringForm = 'observationMonitoringForm';
   static const observationMonitoringDetail = 'observationMonitoringDetail';
+  static const census = 'census';
 
   final GlobalKey<NavigatorState> _rootNavigatorKey =
       GlobalKey<NavigatorState>(debugLabel: 'root');
@@ -152,6 +154,13 @@ class OhtkRouter {
                   },
                 ),
               ],
+            ),
+            GoRoute(
+              name: census,
+              path: '/census',
+              pageBuilder: (context, state) => const NoTransitionPage<void>(
+                child: CensusView(),
+              ),
             ),
             GoRoute(
               path: '/observations',

--- a/lib/services/api/auth_api.dart
+++ b/lib/services/api/auth_api.dart
@@ -73,6 +73,11 @@ class AuthApi extends GraphQlBaseApi {
           role
           consent
           features
+          assignedVillages {
+            id
+            code
+            name
+          }
           avatarUrl
         }
       }

--- a/lib/services/api/census_api.dart
+++ b/lib/services/api/census_api.dart
@@ -1,0 +1,169 @@
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:podd_app/models/animal_species.dart';
+import 'package:podd_app/models/village_census.dart';
+import 'package:podd_app/services/api/graph_ql_base_api.dart';
+
+class CensusApi extends GraphQlBaseApi {
+  CensusApi(ResolveGraphqlClient client) : super(client);
+
+  Future<List<AnimalSpecies>> fetchActiveSpecies() {
+    const query = r'''
+      query AnimalSpecies {
+        animalSpecies {
+          id
+          code
+          name
+          active
+          sortOrder
+        }
+      }
+    ''';
+
+    return runGqlQuery<List<AnimalSpecies>>(
+      query: query,
+      typeConverter: (resp) => (resp['animalSpecies'] as List? ?? const [])
+          .map((species) => AnimalSpecies.fromJson(species))
+          .toList(),
+    );
+  }
+
+  Future<VillageCensusSnapshot?> getLatestVillageCensus(int villageId) async {
+    const query = r'''
+      query LatestVillageCensus($villageId: Int!) {
+        latestVillageCensus(villageId: $villageId) {
+          id
+          censusDate
+          submittedAt
+          village {
+            id
+            code
+            name
+          }
+          facts {
+            species {
+              id
+              code
+              name
+              active
+              sortOrder
+            }
+            animalQuantity
+            householdQuantity
+          }
+        }
+      }
+    ''';
+
+    if (!await ensureAuthCookieIsSet()) {
+      throw GraphQlException(
+        message: 'Cookies are invalid',
+        query: query,
+        queryName: 'LatestVillageCensus',
+      );
+    }
+
+    final response = await resolveClient().query(
+      QueryOptions(
+        document: gql(query),
+        variables: {'villageId': villageId},
+        fetchPolicy: FetchPolicy.networkOnly,
+        cacheRereadPolicy: CacheRereadPolicy.ignoreAll,
+      ),
+    );
+
+    if (response.hasException) {
+      if (response.exception?.linkException != null) {
+        throw response.exception!.linkException!;
+      }
+      throw response.exception!;
+    }
+
+    final snapshot = response.data?['latestVillageCensus'];
+    if (snapshot == null) {
+      return null;
+    }
+    return VillageCensusSnapshot.fromJson(snapshot);
+  }
+
+  Future<VillageCensusSubmitResult> submitVillageCensusSnapshot({
+    required int villageId,
+    required String censusDate,
+    required List<AnimalCensusFactInput> facts,
+  }) async {
+    const mutation = r'''
+      mutation SubmitVillageCensusSnapshot(
+        $villageId: Int!,
+        $censusDate: Date!,
+        $facts: [AnimalCensusFactInput!]!
+      ) {
+        submitVillageCensusSnapshot(
+          villageId: $villageId,
+          censusDate: $censusDate,
+          facts: $facts
+        ) {
+          result {
+            __typename
+            ... on VillageCensusSnapshotType {
+              id
+              censusDate
+              submittedAt
+              village {
+                id
+                code
+                name
+              }
+              facts {
+                species {
+                  id
+                  code
+                  name
+                  active
+                  sortOrder
+                }
+                animalQuantity
+                householdQuantity
+              }
+            }
+            ... on VillageCensusSnapshotProblem {
+              fields {
+                name
+                message
+              }
+              message
+            }
+          }
+        }
+      }
+    ''';
+
+    try {
+      return runGqlMutation<VillageCensusSubmitResult>(
+        mutation: mutation,
+        variables: {
+          'villageId': villageId,
+          'censusDate': censusDate,
+          'facts': facts.map((fact) => fact.toJson()).toList(),
+        },
+        parseData: (resp) {
+          final result = resp?['result'];
+          if (result?['__typename'] == 'VillageCensusSnapshotType') {
+            return VillageCensusSubmitSuccess(
+              VillageCensusSnapshot.fromJson(result),
+            );
+          }
+
+          final fieldMessages = (result?['fields'] as List? ?? const [])
+              .map((field) => field['message'].toString())
+              .toList();
+          final message = result?['message']?.toString();
+          return VillageCensusSubmitValidationFailure([
+            ...fieldMessages,
+            if (message != null && message.isNotEmpty) message,
+          ]);
+        },
+      );
+    } on OperationException catch (e) {
+      return VillageCensusSubmitFailure(e);
+    }
+  }
+}

--- a/lib/services/api/register_api.dart
+++ b/lib/services/api/register_api.dart
@@ -2,6 +2,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:podd_app/models/inviation_code_result.dart';
 import 'package:podd_app/models/login_result.dart';
 import 'package:podd_app/models/register_result.dart';
+import 'package:podd_app/models/village.dart';
 import 'package:podd_app/services/api/graph_ql_base_api.dart';
 
 class RegisterApi extends GraphQlBaseApi {
@@ -18,6 +19,11 @@ class RegisterApi extends GraphQlBaseApi {
               code
               name
             }
+            villages {
+              id
+              code
+              name
+            }
           }
         }
     ''';
@@ -31,6 +37,9 @@ class RegisterApi extends GraphQlBaseApi {
             resp['authority']['name'],
             resp['generatedUsername'],
             resp['generatedEmail'],
+            (resp['villages'] as List? ?? const [])
+                .map((village) => Village.fromJson(village))
+                .toList(),
           );
         },
       );

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:logger/logger.dart';
+import 'package:podd_app/constants.dart';
 import 'package:podd_app/locator.dart';
 import 'package:podd_app/models/login_result.dart';
 import 'package:podd_app/models/user_profile.dart';
+import 'package:podd_app/models/village.dart';
 import 'package:podd_app/services/gql_service.dart';
 import 'package:podd_app/services/jwt.dart';
 import 'package:podd_app/services/observation_definition_service.dart';
@@ -22,6 +24,8 @@ abstract class IAuthService extends Listenable {
 
   UserProfile? get userProfile;
 
+  Village? get selectedVillage;
+
   Future<AuthResult> authenticate(String username, String password);
 
   Future<void> logout();
@@ -39,6 +43,8 @@ abstract class IAuthService extends Listenable {
   updateConfirmedConsent();
 
   updateAvatarUrl(String avatarUrl);
+
+  Future<void> selectVillage(int villageId);
 }
 
 class AuthService with ListenableServiceMixin implements IAuthService {
@@ -68,8 +74,13 @@ class AuthService with ListenableServiceMixin implements IAuthService {
   @override
   UserProfile? get userProfile => _userProfile;
 
+  final ReactiveValue<Village?> _selectedVillage =
+      ReactiveValue<Village?>(null);
+  @override
+  Village? get selectedVillage => _selectedVillage.value;
+
   AuthService() {
-    listenToReactiveValues([_isLogin]);
+    listenToReactiveValues([_isLogin, _selectedVillage]);
   }
 
   init() async {
@@ -84,6 +95,7 @@ class AuthService with ListenableServiceMixin implements IAuthService {
     if (token != null) {
       _token = token;
       _userProfile = await _secureStorageService.getUserProfile();
+      await _syncSelectedVillage();
       var isExpired = await requestAccessTokenIfExpired();
       if (isExpired) {
         _isLogin.value = false;
@@ -155,6 +167,7 @@ class AuthService with ListenableServiceMixin implements IAuthService {
   _fetchProfile() async {
     var profile = await _authApi.getUserProfile();
     _userProfile = profile;
+    await _syncSelectedVillage();
 
     await _secureStorageService.setUserProfile(profile);
     await _reportTypeService.sync();
@@ -220,5 +233,43 @@ class AuthService with ListenableServiceMixin implements IAuthService {
       _userProfile!.avatarUrl = avatarUrl;
       _secureStorageService.setUserProfile(_userProfile!);
     }
+  }
+
+  Future<void> _syncSelectedVillage() async {
+    final villages = _userProfile?.assignedVillages ?? const <Village>[];
+    if (villages.isEmpty) {
+      _selectedVillage.value = null;
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    final storedVillageId = prefs.getInt(selectedVillageIdKey);
+    final selected = villages.firstWhere(
+      (village) => village.id == storedVillageId,
+      orElse: () => villages.first,
+    );
+
+    _selectedVillage.value = selected;
+    await prefs.setInt(selectedVillageIdKey, selected.id);
+  }
+
+  @override
+  Future<void> selectVillage(int villageId) async {
+    final villages = _userProfile?.assignedVillages ?? const <Village>[];
+    Village? selected;
+    for (final village in villages) {
+      if (village.id == villageId) {
+        selected = village;
+        break;
+      }
+    }
+
+    if (selected == null) {
+      return;
+    }
+
+    final prefs = await SharedPreferences.getInstance();
+    _selectedVillage.value = selected;
+    await prefs.setInt(selectedVillageIdKey, selected.id);
   }
 }

--- a/lib/services/census_service.dart
+++ b/lib/services/census_service.dart
@@ -1,0 +1,50 @@
+import 'package:podd_app/locator.dart';
+import 'package:podd_app/models/animal_species.dart';
+import 'package:podd_app/models/village_census.dart';
+import 'package:podd_app/services/api/census_api.dart';
+
+abstract class ICensusService {
+  Future<List<AnimalSpecies>> fetchActiveSpecies();
+
+  Future<VillageCensusSnapshot?> getLatestVillageCensus(int villageId);
+
+  Future<VillageCensusSubmitResult> submitVillageCensusSnapshot({
+    required int villageId,
+    required DateTime censusDate,
+    required List<AnimalCensusFactInput> facts,
+  });
+}
+
+class CensusService implements ICensusService {
+  final CensusApi _censusApi = locator<CensusApi>();
+
+  @override
+  Future<List<AnimalSpecies>> fetchActiveSpecies() {
+    return _censusApi.fetchActiveSpecies();
+  }
+
+  @override
+  Future<VillageCensusSnapshot?> getLatestVillageCensus(int villageId) {
+    return _censusApi.getLatestVillageCensus(villageId);
+  }
+
+  @override
+  Future<VillageCensusSubmitResult> submitVillageCensusSnapshot({
+    required int villageId,
+    required DateTime censusDate,
+    required List<AnimalCensusFactInput> facts,
+  }) {
+    return _censusApi.submitVillageCensusSnapshot(
+      villageId: villageId,
+      censusDate: _dateOnly(censusDate),
+      facts: facts,
+    );
+  }
+
+  String _dateOnly(DateTime date) {
+    final year = date.year.toString().padLeft(4, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '$year-$month-$day';
+  }
+}

--- a/lib/ui/census/census_view.dart
+++ b/lib/ui/census/census_view.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:podd_app/components/flat_button.dart';
+import 'package:podd_app/models/animal_species.dart';
+import 'package:podd_app/models/village_census.dart';
+import 'package:podd_app/ui/census/census_view_model.dart';
+import 'package:stacked/stacked.dart';
+
+class CensusView extends StatelessWidget {
+  const CensusView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelBuilder<CensusViewModel>.reactive(
+      viewModelBuilder: () => CensusViewModel(),
+      builder: (context, viewModel, _) {
+        if (viewModel.isBusy) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        return RefreshIndicator(
+          onRefresh: viewModel.init,
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
+            children: [
+              Text(
+                'Village census',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 8),
+              Text(viewModel.selectedVillage?.displayName ?? 'No village'),
+              const SizedBox(height: 20),
+              if (!viewModel.hasCensusAccess)
+                const Text('Census is not available for this account.'),
+              if (viewModel.hasError)
+                Text(
+                  viewModel.modelError.toString(),
+                  style: const TextStyle(color: Colors.red),
+                ),
+              if (viewModel.hasCensusAccess) ...[
+                _LatestCensus(snapshot: viewModel.latestCensus),
+                const SizedBox(height: 24),
+                if (!viewModel.hasSpecies)
+                  const Text('No active animal species are configured.'),
+                if (viewModel.hasSpecies) _CensusForm(viewModel: viewModel),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _LatestCensus extends StatelessWidget {
+  final VillageCensusSnapshot? snapshot;
+
+  const _LatestCensus({required this.snapshot});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Latest census', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 8),
+        if (snapshot == null)
+          const Text('No census has been submitted yet.')
+        else ...[
+          Text('Date: ${_dateLabel(snapshot!.censusDate)}'),
+          const SizedBox(height: 8),
+          for (final fact in snapshot!.facts)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 4),
+              child: Text(
+                '${fact.species.displayName}: '
+                '${fact.animalQuantity} animals, '
+                '${fact.householdQuantity} households',
+              ),
+            ),
+        ],
+      ],
+    );
+  }
+
+  String _dateLabel(DateTime? date) {
+    if (date == null) {
+      return '-';
+    }
+    final year = date.year.toString().padLeft(4, '0');
+    final month = date.month.toString().padLeft(2, '0');
+    final day = date.day.toString().padLeft(2, '0');
+    return '$year-$month-$day';
+  }
+}
+
+class _CensusForm extends StatelessWidget {
+  final CensusViewModel viewModel;
+
+  const _CensusForm({required this.viewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Submit census', style: Theme.of(context).textTheme.titleMedium),
+        const SizedBox(height: 12),
+        for (final item in viewModel.species)
+          _SpeciesQuantityRow(item, viewModel),
+        if (viewModel.hasErrorForKey('submit')) ...[
+          const SizedBox(height: 12),
+          Text(
+            viewModel.error('submit'),
+            style: const TextStyle(color: Colors.red),
+          ),
+        ],
+        if (viewModel.message != null) ...[
+          const SizedBox(height: 12),
+          Text(
+            viewModel.message!,
+            style: TextStyle(color: Colors.green.shade700),
+          ),
+        ],
+        const SizedBox(height: 20),
+        SizedBox(
+          width: double.infinity,
+          child: FlatButton.primary(
+            onPressed:
+                viewModel.busy('submit') ? null : () => viewModel.submit(),
+            child: viewModel.busy('submit')
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(color: Colors.white),
+                  )
+                : Text('Submit census', style: TextStyle(fontSize: 15.sp)),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SpeciesQuantityRow extends StatelessWidget {
+  final AnimalSpecies species;
+  final CensusViewModel viewModel;
+
+  const _SpeciesQuantityRow(this.species, this.viewModel);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(species.displayName),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  onChanged: (value) =>
+                      viewModel.setAnimalQuantity(species.id, value),
+                  decoration: const InputDecoration(
+                    labelText: 'Animals',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: TextField(
+                  keyboardType: TextInputType.number,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  onChanged: (value) =>
+                      viewModel.setHouseholdQuantity(species.id, value),
+                  decoration: const InputDecoration(
+                    labelText: 'Households',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/census/census_view_model.dart
+++ b/lib/ui/census/census_view_model.dart
@@ -80,11 +80,18 @@ class CensusViewModel extends BaseViewModel {
     }
 
     setBusyForObject('submit', true);
-    final result = await censusService.submitVillageCensusSnapshot(
-      villageId: selectedVillage!.id,
-      censusDate: DateTime.now(),
-      facts: facts,
-    );
+    VillageCensusSubmitResult? result;
+    try {
+      result = await censusService.submitVillageCensusSnapshot(
+        villageId: selectedVillage!.id,
+        censusDate: DateTime.now(),
+        facts: facts,
+      );
+    } catch (e) {
+      setErrorForObject('submit', e.toString());
+    } finally {
+      setBusyForObject('submit', false);
+    }
 
     if (result is VillageCensusSubmitSuccess) {
       latestCensus = result.snapshot;
@@ -95,7 +102,6 @@ class CensusViewModel extends BaseViewModel {
       setErrorForObject('submit', result.messages.join(', '));
     }
 
-    setBusyForObject('submit', false);
     notifyListeners();
     return result;
   }

--- a/lib/ui/census/census_view_model.dart
+++ b/lib/ui/census/census_view_model.dart
@@ -1,0 +1,145 @@
+import 'package:podd_app/locator.dart';
+import 'package:podd_app/models/animal_species.dart';
+import 'package:podd_app/models/village.dart';
+import 'package:podd_app/models/village_census.dart';
+import 'package:podd_app/services/auth_service.dart';
+import 'package:podd_app/services/census_service.dart';
+import 'package:stacked/stacked.dart';
+
+class CensusViewModel extends BaseViewModel {
+  final IAuthService authService = locator<IAuthService>();
+  final ICensusService censusService = locator<ICensusService>();
+
+  List<AnimalSpecies> species = [];
+  VillageCensusSnapshot? latestCensus;
+  final animalQuantities = <int, String>{};
+  final householdQuantities = <int, String>{};
+  String? message;
+
+  CensusViewModel() {
+    init();
+  }
+
+  Village? get selectedVillage => authService.selectedVillage;
+
+  bool get hasCensusAccess =>
+      (authService.userProfile?.hasFeatureEnabled('animal_census_enabled') ??
+          false) &&
+      selectedVillage != null;
+
+  bool get hasSpecies => species.isNotEmpty;
+
+  Future<void> init() async {
+    setBusy(true);
+    message = null;
+    clearErrors();
+
+    if (!hasCensusAccess) {
+      setBusy(false);
+      return;
+    }
+
+    try {
+      species = await censusService.fetchActiveSpecies();
+      for (final item in species) {
+        animalQuantities.putIfAbsent(item.id, () => '');
+        householdQuantities.putIfAbsent(item.id, () => '');
+      }
+      latestCensus =
+          await censusService.getLatestVillageCensus(selectedVillage!.id);
+    } catch (e) {
+      setError(e.toString());
+    }
+
+    setBusy(false);
+  }
+
+  void setAnimalQuantity(int speciesId, String value) {
+    animalQuantities[speciesId] = value.trim();
+    _clearSubmitError();
+  }
+
+  void setHouseholdQuantity(int speciesId, String value) {
+    householdQuantities[speciesId] = value.trim();
+    _clearSubmitError();
+  }
+
+  Future<VillageCensusSubmitResult?> submit() async {
+    _clearSubmitError();
+    message = null;
+
+    if (!hasCensusAccess) {
+      setErrorForObject('submit', 'Village census is not available.');
+      return null;
+    }
+
+    final facts = _buildFacts();
+    if (facts == null) {
+      notifyListeners();
+      return null;
+    }
+
+    setBusyForObject('submit', true);
+    final result = await censusService.submitVillageCensusSnapshot(
+      villageId: selectedVillage!.id,
+      censusDate: DateTime.now(),
+      facts: facts,
+    );
+
+    if (result is VillageCensusSubmitSuccess) {
+      latestCensus = result.snapshot;
+      message = 'Census submitted.';
+    } else if (result is VillageCensusSubmitValidationFailure) {
+      setErrorForObject('submit', result.messages.join(', '));
+    } else if (result is VillageCensusSubmitFailure) {
+      setErrorForObject('submit', result.messages.join(', '));
+    }
+
+    setBusyForObject('submit', false);
+    notifyListeners();
+    return result;
+  }
+
+  List<AnimalCensusFactInput>? _buildFacts() {
+    final facts = <AnimalCensusFactInput>[];
+    for (final item in species) {
+      final animalQuantity = _parseQuantity(animalQuantities[item.id]);
+      final householdQuantity = _parseQuantity(householdQuantities[item.id]);
+
+      if (animalQuantity == null || householdQuantity == null) {
+        setErrorForObject(
+          'submit',
+          'Enter non-negative animal and household quantities for every species.',
+        );
+        return null;
+      }
+
+      facts.add(
+        AnimalCensusFactInput(
+          speciesId: item.id,
+          animalQuantity: animalQuantity,
+          householdQuantity: householdQuantity,
+        ),
+      );
+    }
+    return facts;
+  }
+
+  int? _parseQuantity(String? value) {
+    if (value == null || value.isEmpty) {
+      return null;
+    }
+    final parsed = int.tryParse(value);
+    if (parsed == null || parsed < 0) {
+      return null;
+    }
+    return parsed;
+  }
+
+  void _clearSubmitError() {
+    if (hasErrorForKey('submit')) {
+      setErrorForObject('submit', null);
+    }
+    message = null;
+  }
+}

--- a/lib/ui/home/home_view.dart
+++ b/lib/ui/home/home_view.dart
@@ -108,6 +108,11 @@ class HomeView extends HookWidget {
                   'Observations',
               icon: const Icon(Icons.format_list_bulleted),
             ),
+          if (viewModel.hasAnimalCensusFeature)
+            const BottomNavigationBarItem(
+              label: 'Census',
+              icon: Icon(Icons.fact_check_outlined),
+            ),
           BottomNavigationBarItem(
             label: AppLocalizations.of(context)?.profileTabTitle ?? 'Profile',
             icon: const Icon(Icons.account_circle),
@@ -152,8 +157,13 @@ class HomeView extends HookWidget {
           viewModel.hasObservationFeature) {
         return 1;
       }
-      if (location.startsWith('/profile')) {
+      if (location.startsWith('/census') && viewModel.hasAnimalCensusFeature) {
         return viewModel.hasObservationFeature ? 2 : 1;
+      }
+      if (location.startsWith('/profile')) {
+        return 1 +
+            (viewModel.hasObservationFeature ? 1 : 0) +
+            (viewModel.hasAnimalCensusFeature ? 1 : 0);
       }
     } on AssertionError catch (e) {
       debugPrint(e.toString());
@@ -162,20 +172,15 @@ class HomeView extends HookWidget {
   }
 
   void _onItemTapped(int index, BuildContext context, HomeViewModel viewModel) {
-    switch (index) {
-      case 0:
-        GoRouter.of(context).go('/reports');
-        break;
-      case 1:
-        if (viewModel.hasObservationFeature) {
-          GoRouter.of(context).go('/observations');
-        } else {
-          GoRouter.of(context).go('/profile');
-        }
-        break;
-      case 2:
-        GoRouter.of(context).go('/profile');
-        break;
+    final paths = [
+      '/reports',
+      if (viewModel.hasObservationFeature) '/observations',
+      if (viewModel.hasAnimalCensusFeature) '/census',
+      '/profile',
+    ];
+
+    if (index >= 0 && index < paths.length) {
+      GoRouter.of(context).go(paths[index]);
     }
   }
 }

--- a/lib/ui/home/home_view_model.dart
+++ b/lib/ui/home/home_view_model.dart
@@ -70,6 +70,10 @@ class HomeViewModel extends IndexTrackingViewModel {
   bool get hasObservationFeature =>
       userProfile?.hasFeatureEnabled("observation") ?? false;
 
+  bool get hasAnimalCensusFeature =>
+      (userProfile?.hasFeatureEnabled("animal_census_enabled") ?? false) &&
+      (userProfile?.hasAssignedVillages ?? false);
+
   setupFirebaseMessaging({
     NotificationMessageCallback? onBackgroundMessage,
     NotificationMessageCallback? onForegroundMessage,

--- a/lib/ui/profile/profile_view.dart
+++ b/lib/ui/profile/profile_view.dart
@@ -60,6 +60,32 @@ class ProfileView extends StatelessWidget {
                                 value: viewModel.authorityName,
                                 crossAxisAlignment: CrossAxisAlignment.center,
                               ),
+                              if (viewModel.assignedVillageNames != null) ...[
+                                const SizedBox(height: 12),
+                                DisplayField(
+                                  label: 'Villages',
+                                  value: viewModel.assignedVillageNames,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                ),
+                              ],
+                              if (viewModel.hasMultipleAssignedVillages) ...[
+                                const SizedBox(height: 12),
+                                DropdownButtonFormField<int>(
+                                  initialValue: viewModel.selectedVillageId,
+                                  decoration: const InputDecoration(
+                                    labelText: 'Active village',
+                                  ),
+                                  items: viewModel.assignedVillages
+                                      .map(
+                                        (village) => DropdownMenuItem<int>(
+                                          value: village.id,
+                                          child: Text(village.displayName),
+                                        ),
+                                      )
+                                      .toList(),
+                                  onChanged: viewModel.selectVillage,
+                                ),
+                              ],
                             ],
                           ),
                           Divider(

--- a/lib/ui/profile/profile_view_model.dart
+++ b/lib/ui/profile/profile_view_model.dart
@@ -2,6 +2,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:podd_app/constants.dart';
 import 'package:podd_app/locator.dart';
 import 'package:podd_app/models/profile_result.dart';
+import 'package:podd_app/models/village.dart';
 import 'package:podd_app/services/auth_service.dart';
 import 'package:podd_app/services/profile_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,6 +21,9 @@ class ProfileViewModel extends BaseViewModel {
   String? email;
   String? telephone;
   String? address;
+  String? assignedVillageNames;
+  List<Village> assignedVillages = [];
+  Village? selectedVillage;
   String? avatarUrl;
 
   String language = "en";
@@ -40,11 +44,31 @@ class ProfileViewModel extends BaseViewModel {
       username = userProfile.username;
       email = userProfile.email;
       authorityName = userProfile.authorityName;
+      assignedVillages = userProfile.assignedVillages;
+      selectedVillage =
+          authService.selectedVillage ?? userProfile.primaryAssignedVillage;
+      assignedVillageNames = userProfile.hasAssignedVillages
+          ? userProfile.assignedVillageNames
+          : null;
       avatarUrl = userProfile.avatarUrl;
       address = userProfile.address;
       notifyListeners();
     }
     language = prefs.getString(languageKey) ?? "en";
+  }
+
+  bool get hasMultipleAssignedVillages => assignedVillages.length > 1;
+
+  int? get selectedVillageId => selectedVillage?.id;
+
+  Future<void> selectVillage(int? villageId) async {
+    if (villageId == null) {
+      return;
+    }
+
+    await authService.selectVillage(villageId);
+    selectedVillage = authService.selectedVillage;
+    notifyListeners();
   }
 
   void setFirstName(String value) {

--- a/lib/ui/register/register_view.dart
+++ b/lib/ui/register/register_view.dart
@@ -116,6 +116,14 @@ class _DetailCodeForm extends StackedHookView<RegisterViewModel> {
                 value: viewModel.authorityName,
                 crossAxisAlignment: CrossAxisAlignment.center,
               ),
+              if (viewModel.hasVillages) ...[
+                const SizedBox(height: 12),
+                DisplayField(
+                  label: 'Villages',
+                  value: viewModel.villageNames,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                ),
+              ],
             ],
           ),
           Divider(

--- a/lib/ui/register/register_view_model.dart
+++ b/lib/ui/register/register_view_model.dart
@@ -1,6 +1,7 @@
 import 'package:podd_app/locator.dart';
 import 'package:podd_app/models/inviation_code_result.dart';
 import 'package:podd_app/models/register_result.dart';
+import 'package:podd_app/models/village.dart';
 import 'package:podd_app/services/register_service.dart';
 import 'package:stacked/stacked.dart';
 import 'package:podd_app/l10n/app_localizations.dart';
@@ -15,6 +16,7 @@ class RegisterViewModel extends BaseViewModel {
 
   String? invitationCode;
   String? authorityName;
+  List<Village> villages = [];
 
   String? username;
   String? firstName;
@@ -39,6 +41,7 @@ class RegisterViewModel extends BaseViewModel {
     if (result is InvitationCodeSuccess) {
       state = RegisterState.detail;
       authorityName = result.authorityName;
+      villages = result.villages;
       username = result.generatedUsername;
       email = result.generatedEmail;
       notifyListeners();
@@ -48,6 +51,11 @@ class RegisterViewModel extends BaseViewModel {
 
     setBusy(false);
   }
+
+  bool get hasVillages => villages.isNotEmpty;
+
+  String get villageNames =>
+      villages.map((village) => village.displayName).join(', ');
 
   _clearErrorForKey(String key) {
     if (hasErrorForKey(key)) {

--- a/test/services/auth_api_test.dart
+++ b/test/services/auth_api_test.dart
@@ -102,6 +102,14 @@ void main() {
             'role': 'reporter',
             'consent': true,
             'features': <String>[],
+            'assignedVillages': [
+              {
+                '__typename': 'VillageType',
+                'id': 11,
+                'code': 'V001',
+                'name': 'Village One',
+              }
+            ],
             'avatarUrl': null,
           }
         }
@@ -113,6 +121,7 @@ void main() {
       expect(profile, isA<UserProfile>());
       expect(profile.username, 'alice');
       expect(profile.authorityId, 7);
+      expect(profile.assignedVillageNames, 'V001 - Village One');
     });
   });
 }

--- a/test/services/census_api_test.dart
+++ b/test/services/census_api_test.dart
@@ -1,0 +1,180 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:logger/logger.dart';
+import 'package:podd_app/locator.dart';
+import 'package:podd_app/models/village_census.dart';
+import 'package:podd_app/services/api/census_api.dart';
+
+class QueueLink extends Link {
+  final List<Map<String, dynamic>> responses;
+  final requests = <Request>[];
+
+  QueueLink(this.responses);
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    requests.add(request);
+    final data = responses.removeAt(0);
+    return Stream.value(Response(data: data, response: {'data': data}));
+  }
+}
+
+GraphQLClient clientFor(QueueLink link) {
+  return GraphQLClient(link: link, cache: GraphQLCache());
+}
+
+CensusApi censusApiFor(QueueLink link) {
+  final api = CensusApi(() => clientFor(link));
+  api.baseLogger = null;
+  return api;
+}
+
+void main() {
+  setUpAll(() {
+    if (!locator.isRegistered<Logger>()) {
+      locator.registerSingleton<Logger>(Logger());
+    }
+  });
+
+  group('CensusApi GraphQL contract', () {
+    test('fetchActiveSpecies parses active species list', () async {
+      final link = QueueLink([
+        {
+          '__typename': 'Query',
+          'animalSpecies': [
+            {
+              '__typename': 'AnimalSpeciesType',
+              'id': 1,
+              'code': 'CATTLE',
+              'name': 'Cattle',
+              'active': true,
+              'sortOrder': 1,
+            },
+            {
+              '__typename': 'AnimalSpeciesType',
+              'id': 2,
+              'code': 'BUFFALO',
+              'name': 'Buffalo',
+              'active': true,
+              'sortOrder': 2,
+            },
+          ],
+        }
+      ]);
+      final api = censusApiFor(link);
+
+      final species = await api.fetchActiveSpecies();
+
+      expect(species.map((item) => item.displayName), [
+        'CATTLE - Cattle',
+        'BUFFALO - Buffalo',
+      ]);
+      expect(link.requests.single.variables, isEmpty);
+    });
+
+    test('getLatestVillageCensus returns null when no snapshot exists',
+        () async {
+      final link = QueueLink([
+        {'__typename': 'Query', 'latestVillageCensus': null}
+      ]);
+      final api = censusApiFor(link);
+
+      final latest = await api.getLatestVillageCensus(11);
+
+      expect(latest, isNull);
+      expect(link.requests.single.variables, {'villageId': 11});
+    });
+
+    test('submitVillageCensusSnapshot parses success union', () async {
+      final link = QueueLink([
+        {
+          '__typename': 'Mutation',
+          'submitVillageCensusSnapshot': {
+            '__typename': 'SubmitVillageCensusSnapshotMutation',
+            'result': {
+              '__typename': 'VillageCensusSnapshotType',
+              'id': 99,
+              'censusDate': '2026-05-05',
+              'submittedAt': '2026-05-05T10:00:00Z',
+              'village': {
+                '__typename': 'VillageType',
+                'id': 11,
+                'code': 'V001',
+                'name': 'Village One',
+              },
+              'facts': [
+                {
+                  'species': {
+                    '__typename': 'AnimalSpeciesType',
+                    'id': 1,
+                    'code': 'CATTLE',
+                    'name': 'Cattle',
+                    'active': true,
+                    'sortOrder': 1,
+                  },
+                  'animalQuantity': 5,
+                  'householdQuantity': 2,
+                }
+              ],
+            }
+          }
+        }
+      ]);
+      final api = censusApiFor(link);
+
+      final result = await api.submitVillageCensusSnapshot(
+        villageId: 11,
+        censusDate: '2026-05-05',
+        facts: const [
+          AnimalCensusFactInput(
+            speciesId: 1,
+            animalQuantity: 5,
+            householdQuantity: 2,
+          )
+        ],
+      );
+
+      expect(result, isA<VillageCensusSubmitSuccess>());
+      final success = result as VillageCensusSubmitSuccess;
+      expect(success.snapshot.facts.single.animalQuantity, 5);
+      expect(link.requests.single.variables['villageId'], 11);
+      expect(link.requests.single.variables['facts'], [
+        {'speciesId': 1, 'animalQuantity': 5, 'householdQuantity': 2}
+      ]);
+    });
+
+    test('submitVillageCensusSnapshot parses validation problem union',
+        () async {
+      final link = QueueLink([
+        {
+          '__typename': 'Mutation',
+          'submitVillageCensusSnapshot': {
+            '__typename': 'SubmitVillageCensusSnapshotMutation',
+            'result': {
+              '__typename': 'VillageCensusSnapshotProblem',
+              'message': null,
+              'fields': [
+                {
+                  '__typename': 'AdminFieldValidationProblem',
+                  'name': 'village_id',
+                  'message': 'reporter is not official for this village',
+                }
+              ],
+            }
+          }
+        }
+      ]);
+      final api = censusApiFor(link);
+
+      final result = await api.submitVillageCensusSnapshot(
+        villageId: 11,
+        censusDate: '2026-05-05',
+        facts: const [],
+      );
+
+      expect(result, isA<VillageCensusSubmitValidationFailure>());
+      final failure = result as VillageCensusSubmitValidationFailure;
+      expect(failure.messages, ['reporter is not official for this village']);
+    });
+  });
+}

--- a/test/services/register_api_test.dart
+++ b/test/services/register_api_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:logger/logger.dart';
+import 'package:podd_app/locator.dart';
+import 'package:podd_app/models/inviation_code_result.dart';
+import 'package:podd_app/services/api/register_api.dart';
+
+class QueueLink extends Link {
+  final List<Map<String, dynamic>> responses;
+  final requests = <Request>[];
+
+  QueueLink(this.responses);
+
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    requests.add(request);
+    final data = responses.removeAt(0);
+    return Stream.value(Response(data: data, response: {'data': data}));
+  }
+}
+
+GraphQLClient clientFor(QueueLink link) {
+  return GraphQLClient(link: link, cache: GraphQLCache());
+}
+
+RegisterApi registerApiFor(QueueLink link) {
+  final api = RegisterApi(() => clientFor(link));
+  api.baseLogger = null;
+  return api;
+}
+
+void main() {
+  setUpAll(() {
+    if (!locator.isRegistered<Logger>()) {
+      locator.registerSingleton<Logger>(Logger());
+    }
+  });
+
+  group('RegisterApi GraphQL contract', () {
+    test('checkInvitationCode parses scoped villages', () async {
+      final link = QueueLink([
+        {
+          '__typename': 'Query',
+          'checkInvitationCode': {
+            '__typename': 'CheckInvitationCodeType',
+            'code': 'INV001',
+            'generatedUsername': 'reporter001',
+            'generatedEmail': 'reporter001@example.test',
+            'authority': {
+              '__typename': 'AuthorityType',
+              'code': 'AUTH',
+              'name': 'Authority',
+            },
+            'villages': [
+              {
+                '__typename': 'VillageType',
+                'id': 11,
+                'code': 'V001',
+                'name': 'Village One',
+              },
+              {
+                '__typename': 'VillageType',
+                'id': 12,
+                'code': 'V002',
+                'name': 'Village Two',
+              },
+            ],
+          }
+        }
+      ]);
+      final api = registerApiFor(link);
+
+      final result = await api.checkInvitationCode('INV001');
+
+      expect(result, isA<InvitationCodeSuccess>());
+      final success = result as InvitationCodeSuccess;
+      expect(success.authorityName, 'Authority');
+      expect(success.generatedUsername, 'reporter001');
+      expect(success.generatedEmail, 'reporter001@example.test');
+      expect(success.villageNames, 'V001 - Village One, V002 - Village Two');
+      expect(link.requests.single.variables, {'code': 'INV001'});
+    });
+  });
+}

--- a/test/ui/login_view_model_test.dart
+++ b/test/ui/login_view_model_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:podd_app/locator.dart';
 import 'package:podd_app/models/login_result.dart';
 import 'package:podd_app/models/user_profile.dart';
+import 'package:podd_app/models/village.dart';
 import 'package:podd_app/services/auth_service.dart';
 import 'package:podd_app/services/config_service.dart';
 import 'package:podd_app/services/gql_service.dart';
@@ -42,6 +43,9 @@ class AuthServiceMock extends ChangeNotifier implements IAuthService {
   UserProfile? get userProfile => null;
 
   @override
+  Village? get selectedVillage => null;
+
+  @override
   Future<void> saveTokenAndFetchProfile(AuthSuccess loginSuccess) {
     throw UnimplementedError();
   }
@@ -68,6 +72,11 @@ class AuthServiceMock extends ChangeNotifier implements IAuthService {
 
   @override
   updateAvatarUrl(String avatarUrl) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> selectVillage(int villageId) {
     throw UnimplementedError();
   }
 }


### PR DESCRIPTION
## Summary

Adds the mobile side of the FAO Tenant Village Census MVP.

Changes include:

- village-scoped invitation/profile parsing
- assigned village display in registration and profile
- active village selection for reporters assigned to multiple villages
- Census tab gated by `features.animal_census_enabled` and assigned villages
- active species fetch through the reporter-readable `animalSpecies` query
- latest census display for the selected village
- complete species-only census submit form
- client-side non-negative quantity validation
- backend validation error display for cases such as volunteer/unofficial rejection

## Validation

- `flutter --version` -> Flutter 3.41.9 / Dart 3.11.5
- `flutter analyze` -> no issues
- `flutter test` -> 96 tests passed
- `git diff --check` -> clean

## Notes

This PR depends on the companion `ohtk-api` FAO pending-slices PR because it consumes `assignedVillages`, `animalSpecies`, `latestVillageCensus`, and `submitVillageCensusSnapshot`. Manual device smoke was not run in this closure pass.
