### PR TITLE
Add FAO mobile census draft cache

### DIFF
--- a/.maestro/fao_census_smoke.yaml
+++ b/.maestro/fao_census_smoke.yaml
@@ -1,0 +1,78 @@
+appId: org.poddtoolkit.poddMobile
+name: FAO mobile census draft cache smoke
+---
+- launchApp
+- extendedWaitUntil:
+    visible:
+      id: "login.server_dropdown"
+    timeout: 30000
+- tapOn:
+    id: "login.server_dropdown"
+- tapOn: "Local public"
+- tapOn:
+    id: "login.username_field"
+- inputText: "codex_poc"
+- tapOn:
+    id: "login.password_field"
+- inputText: "codex_poc"
+- hideKeyboard
+- tapOn:
+    id: "login.submit_button"
+- waitForAnimationToEnd:
+    timeout: 10000
+- tapOn:
+    id: "home.nav.census_tab"
+- extendedWaitUntil:
+    visible:
+      id: "census.title_text"
+    timeout: 30000
+- assertVisible:
+    id: "census.village_text"
+- tapOn:
+    id: "census.CATTLE.animals_field"
+- inputText: "12"
+- tapOn:
+    id: "census.CATTLE.households_field"
+- inputText: "3"
+- hideKeyboard
+- extendedWaitUntil:
+    visible:
+      id: "census.draft_saved_text"
+    timeout: 10000
+- tapOn:
+    id: "home.nav.incidents_tab"
+- tapOn:
+    id: "home.nav.census_tab"
+- extendedWaitUntil:
+    visible:
+      id: "census.title_text"
+    timeout: 30000
+- assertVisible:
+    id: "census.draft_saved_text"
+- assertVisible: "12"
+- assertVisible: "3"
+- tapOn:
+    id: "census.discard_draft_button"
+- assertVisible:
+    id: "census.status_text"
+- assertNotVisible:
+    id: "census.draft_saved_text"
+- tapOn:
+    id: "census.CATTLE.animals_field"
+- inputText: "14"
+- tapOn:
+    id: "census.CATTLE.households_field"
+- inputText: "4"
+- hideKeyboard
+- extendedWaitUntil:
+    visible:
+      id: "census.draft_saved_text"
+    timeout: 10000
+- tapOn:
+    id: "census.submit_button"
+- extendedWaitUntil:
+    visible:
+      id: "census.status_text"
+    timeout: 30000
+- assertNotVisible:
+    id: "census.draft_saved_text"

--- a/.maestro/run_fao_census_smoke.sh
+++ b/.maestro/run_fao_census_smoke.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEVICE_ID="${DEVICE_ID:-emulator-5554}"
+SDK_ROOT="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-/Users/pphetra/Library/Android/sdk}}"
+ADB="${ADB:-$SDK_ROOT/platform-tools/adb}"
+
+cd "$(dirname "$0")/.."
+
+command -v maestro >/dev/null
+command -v flutter >/dev/null
+
+"$ADB" -s "$DEVICE_ID" get-state >/dev/null
+
+python3 .maestro/tenant_proxy.py &
+PROXY_PID="$!"
+cleanup() {
+  kill "$PROXY_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+flutter build apk --debug \
+  --dart-define=TENANT_API_ENDPOINT=http://10.0.2.2:18080/api/servers/ \
+  --dart-define=GRAPHQL_ENDPOINT=https://10.0.2.2/graphql/
+
+"$ADB" -s "$DEVICE_ID" install -r build/app/outputs/flutter-apk/app-debug.apk
+
+"$ADB" -s "$DEVICE_ID" shell pm clear org.poddtoolkit.poddMobile >/dev/null
+"$ADB" -s "$DEVICE_ID" shell monkey -p org.poddtoolkit.poddMobile 1 >/dev/null
+sleep "${WARMUP_SECONDS:-15}"
+"$ADB" -s "$DEVICE_ID" shell am force-stop org.poddtoolkit.poddMobile
+
+maestro check-syntax .maestro/fao_census_smoke.yaml
+
+MAESTRO_CLI_NO_ANALYTICS=1 \
+MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true \
+maestro test --device "$DEVICE_ID" .maestro/fao_census_smoke.yaml

--- a/.maestro/tenant_proxy.py
+++ b/.maestro/tenant_proxy.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps(
+            {
+                "tenants": [
+                    {
+                        "label": "Local public",
+                        "domain": "10.0.2.2",
+                        "external": False,
+                    }
+                ]
+            }
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 18080), Handler).serve_forever()

--- a/lib/components/test_id.dart
+++ b/lib/components/test_id.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/widgets.dart';
+
+class TestId extends StatelessWidget {
+  const TestId({
+    super.key,
+    required this.id,
+    required this.child,
+    this.button = false,
+    this.textField = false,
+    this.liveRegion = false,
+  });
+
+  final String id;
+  final Widget child;
+  final bool button;
+  final bool textField;
+  final bool liveRegion;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      identifier: id,
+      button: button,
+      textField: textField,
+      liveRegion: liveRegion,
+      child: child,
+    );
+  }
+}

--- a/lib/models/animal_species.dart
+++ b/lib/models/animal_species.dart
@@ -21,6 +21,16 @@ class AnimalSpecies {
         sortOrder: json['sortOrder'] as int? ?? 0,
       );
 
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'code': code,
+      'name': name,
+      'active': active,
+      'sortOrder': sortOrder,
+    };
+  }
+
   String get displayName {
     if (code.isEmpty) {
       return name;

--- a/lib/models/village_census.dart
+++ b/lib/models/village_census.dart
@@ -39,6 +39,14 @@ class AnimalCensusFact {
         animalQuantity: json['animalQuantity'] as int? ?? 0,
         householdQuantity: json['householdQuantity'] as int? ?? 0,
       );
+
+  Map<String, dynamic> toJson() {
+    return {
+      'species': species.toJson(),
+      'animalQuantity': animalQuantity,
+      'householdQuantity': householdQuantity,
+    };
+  }
 }
 
 class VillageCensusSnapshot {
@@ -69,6 +77,90 @@ class VillageCensusSnapshot {
             .map((fact) => AnimalCensusFact.fromJson(fact))
             .toList(),
       );
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'village': village?.toJson(),
+      'censusDate': censusDate?.toIso8601String(),
+      'submittedAt': submittedAt,
+      'facts': facts.map((fact) => fact.toJson()).toList(),
+    };
+  }
+}
+
+class VillageCensusDraft {
+  final int villageId;
+  final Map<int, String> animalQuantities;
+  final Map<int, String> householdQuantities;
+  final DateTime savedAt;
+
+  const VillageCensusDraft({
+    required this.villageId,
+    required this.animalQuantities,
+    required this.householdQuantities,
+    required this.savedAt,
+  });
+
+  bool get hasValues {
+    return animalQuantities.values.any((value) => value.isNotEmpty) ||
+        householdQuantities.values.any((value) => value.isNotEmpty);
+  }
+
+  factory VillageCensusDraft.fromJson(Map<String, dynamic> json) {
+    Map<int, String> parseQuantities(dynamic value) {
+      final map = value as Map? ?? const {};
+      return map.map(
+        (key, quantity) => MapEntry(
+          int.parse(key.toString()),
+          quantity?.toString() ?? '',
+        ),
+      );
+    }
+
+    return VillageCensusDraft(
+      villageId: json['villageId'] is int
+          ? json['villageId'] as int
+          : int.parse('${json['villageId']}'),
+      animalQuantities: parseQuantities(json['animalQuantities']),
+      householdQuantities: parseQuantities(json['householdQuantities']),
+      savedAt: DateTime.tryParse(json['savedAt']?.toString() ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    Map<String, String> encodeQuantities(Map<int, String> values) {
+      return values.map(
+        (key, value) => MapEntry(key.toString(), value),
+      );
+    }
+
+    return {
+      'villageId': villageId,
+      'animalQuantities': encodeQuantities(animalQuantities),
+      'householdQuantities': encodeQuantities(householdQuantities),
+      'savedAt': savedAt.toIso8601String(),
+    };
+  }
+}
+
+class VillageCensusReadData {
+  final List<AnimalSpecies> species;
+  final VillageCensusSnapshot? latestCensus;
+  final bool usedCachedSpecies;
+  final bool usedCachedLatestCensus;
+  final String? errorMessage;
+
+  const VillageCensusReadData({
+    required this.species,
+    this.latestCensus,
+    this.usedCachedSpecies = false,
+    this.usedCachedLatestCensus = false,
+    this.errorMessage,
+  });
+
+  bool get usedCache => usedCachedSpecies || usedCachedLatestCensus;
 }
 
 abstract class VillageCensusSubmitResult {}

--- a/lib/services/census_service.dart
+++ b/lib/services/census_service.dart
@@ -1,12 +1,23 @@
+import 'dart:convert';
+
 import 'package:podd_app/locator.dart';
 import 'package:podd_app/models/animal_species.dart';
 import 'package:podd_app/models/village_census.dart';
 import 'package:podd_app/services/api/census_api.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 abstract class ICensusService {
   Future<List<AnimalSpecies>> fetchActiveSpecies();
 
   Future<VillageCensusSnapshot?> getLatestVillageCensus(int villageId);
+
+  Future<VillageCensusReadData> loadVillageCensus(int villageId);
+
+  Future<VillageCensusDraft?> getDraft(int villageId);
+
+  Future<void> saveDraft(VillageCensusDraft draft);
+
+  Future<void> clearDraft(int villageId);
 
   Future<VillageCensusSubmitResult> submitVillageCensusSnapshot({
     required int villageId,
@@ -16,7 +27,16 @@ abstract class ICensusService {
 }
 
 class CensusService implements ICensusService {
-  final CensusApi _censusApi = locator<CensusApi>();
+  static const _speciesCacheKey = 'fao.census.activeSpecies.cache';
+
+  final CensusApi _censusApi;
+  SharedPreferences? _prefs;
+
+  CensusService({
+    CensusApi? censusApi,
+    SharedPreferences? prefs,
+  })  : _censusApi = censusApi ?? locator<CensusApi>(),
+        _prefs = prefs;
 
   @override
   Future<List<AnimalSpecies>> fetchActiveSpecies() {
@@ -26,6 +46,72 @@ class CensusService implements ICensusService {
   @override
   Future<VillageCensusSnapshot?> getLatestVillageCensus(int villageId) {
     return _censusApi.getLatestVillageCensus(villageId);
+  }
+
+  @override
+  Future<VillageCensusReadData> loadVillageCensus(int villageId) async {
+    String? errorMessage;
+    var usedCachedSpecies = false;
+    var usedCachedLatestCensus = false;
+    List<AnimalSpecies> species = const [];
+    VillageCensusSnapshot? latestCensus;
+
+    try {
+      species = await fetchActiveSpecies();
+      await _cacheSpecies(species);
+    } catch (e) {
+      errorMessage = e.toString();
+      species = await _getCachedSpecies();
+      usedCachedSpecies = species.isNotEmpty;
+    }
+
+    try {
+      latestCensus = await getLatestVillageCensus(villageId);
+      await _cacheLatestCensus(villageId, latestCensus);
+    } catch (e) {
+      errorMessage ??= e.toString();
+      latestCensus = await _getCachedLatestCensus(villageId);
+      usedCachedLatestCensus = latestCensus != null;
+    }
+
+    return VillageCensusReadData(
+      species: species,
+      latestCensus: latestCensus,
+      usedCachedSpecies: usedCachedSpecies,
+      usedCachedLatestCensus: usedCachedLatestCensus,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  Future<VillageCensusDraft?> getDraft(int villageId) async {
+    final raw = (await _preferences()).getString(_draftKey(villageId));
+    if (raw == null) {
+      return null;
+    }
+    try {
+      return VillageCensusDraft.fromJson(jsonDecode(raw));
+    } catch (_) {
+      await clearDraft(villageId);
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveDraft(VillageCensusDraft draft) async {
+    if (!draft.hasValues) {
+      await clearDraft(draft.villageId);
+      return;
+    }
+    await (await _preferences()).setString(
+      _draftKey(draft.villageId),
+      jsonEncode(draft.toJson()),
+    );
+  }
+
+  @override
+  Future<void> clearDraft(int villageId) async {
+    await (await _preferences()).remove(_draftKey(villageId));
   }
 
   @override
@@ -47,4 +133,61 @@ class CensusService implements ICensusService {
     final day = date.day.toString().padLeft(2, '0');
     return '$year-$month-$day';
   }
+
+  Future<SharedPreferences> _preferences() async {
+    return _prefs ??= await SharedPreferences.getInstance();
+  }
+
+  Future<void> _cacheSpecies(List<AnimalSpecies> species) async {
+    await (await _preferences()).setString(
+      _speciesCacheKey,
+      jsonEncode(species.map((item) => item.toJson()).toList()),
+    );
+  }
+
+  Future<List<AnimalSpecies>> _getCachedSpecies() async {
+    final raw = (await _preferences()).getString(_speciesCacheKey);
+    if (raw == null) {
+      return const [];
+    }
+    try {
+      return (jsonDecode(raw) as List)
+          .map((item) => AnimalSpecies.fromJson(item))
+          .toList();
+    } catch (_) {
+      await (await _preferences()).remove(_speciesCacheKey);
+      return const [];
+    }
+  }
+
+  Future<void> _cacheLatestCensus(
+    int villageId,
+    VillageCensusSnapshot? latestCensus,
+  ) async {
+    final prefs = await _preferences();
+    final key = _latestCensusKey(villageId);
+    if (latestCensus == null) {
+      await prefs.remove(key);
+      return;
+    }
+    await prefs.setString(key, jsonEncode(latestCensus.toJson()));
+  }
+
+  Future<VillageCensusSnapshot?> _getCachedLatestCensus(int villageId) async {
+    final raw = (await _preferences()).getString(_latestCensusKey(villageId));
+    if (raw == null) {
+      return null;
+    }
+    try {
+      return VillageCensusSnapshot.fromJson(jsonDecode(raw));
+    } catch (_) {
+      await (await _preferences()).remove(_latestCensusKey(villageId));
+      return null;
+    }
+  }
+
+  String _latestCensusKey(int villageId) =>
+      'fao.census.latest.$villageId.cache';
+
+  String _draftKey(int villageId) => 'fao.census.draft.$villageId';
 }

--- a/lib/ui/census/census_view.dart
+++ b/lib/ui/census/census_view.dart
@@ -38,6 +38,13 @@ class CensusView extends StatelessWidget {
                   viewModel.modelError.toString(),
                   style: const TextStyle(color: Colors.red),
                 ),
+              if (viewModel.cacheMessage != null) ...[
+                Text(
+                  viewModel.cacheMessage!,
+                  style: TextStyle(color: Colors.orange.shade800),
+                ),
+                const SizedBox(height: 12),
+              ],
               if (viewModel.hasCensusAccess) ...[
                 _LatestCensus(snapshot: viewModel.latestCensus),
                 const SizedBox(height: 24),
@@ -107,6 +114,23 @@ class _CensusForm extends StatelessWidget {
       children: [
         Text('Submit census', style: Theme.of(context).textTheme.titleMedium),
         const SizedBox(height: 12),
+        if (viewModel.hasDraft) ...[
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Draft saved',
+                  style: TextStyle(color: Colors.blueGrey.shade700),
+                ),
+              ),
+              TextButton(
+                onPressed: viewModel.discardDraft,
+                child: const Text('Discard'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+        ],
         for (final item in viewModel.species)
           _SpeciesQuantityRow(item, viewModel),
         if (viewModel.hasErrorForKey('submit')) ...[
@@ -161,7 +185,11 @@ class _SpeciesQuantityRow extends StatelessWidget {
           Row(
             children: [
               Expanded(
-                child: TextField(
+                child: TextFormField(
+                  key: ValueKey(
+                    'animal-${species.id}-${viewModel.fieldVersion}',
+                  ),
+                  initialValue: viewModel.animalQuantities[species.id] ?? '',
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   onChanged: (value) =>
@@ -174,7 +202,11 @@ class _SpeciesQuantityRow extends StatelessWidget {
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: TextField(
+                child: TextFormField(
+                  key: ValueKey(
+                    'household-${species.id}-${viewModel.fieldVersion}',
+                  ),
+                  initialValue: viewModel.householdQuantities[species.id] ?? '',
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly],
                   onChanged: (value) =>

--- a/lib/ui/census/census_view.dart
+++ b/lib/ui/census/census_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:podd_app/components/flat_button.dart';
+import 'package:podd_app/components/test_id.dart';
 import 'package:podd_app/models/animal_species.dart';
 import 'package:podd_app/models/village_census.dart';
 import 'package:podd_app/ui/census/census_view_model.dart';
@@ -24,12 +25,19 @@ class CensusView extends StatelessWidget {
           child: ListView(
             padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
             children: [
-              Text(
-                'Village census',
-                style: Theme.of(context).textTheme.titleLarge,
+              TestId(
+                id: 'census.title_text',
+                child: Text(
+                  'Village census',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
               ),
               const SizedBox(height: 8),
-              Text(viewModel.selectedVillage?.displayName ?? 'No village'),
+              TestId(
+                id: 'census.village_text',
+                child: Text(
+                    viewModel.selectedVillage?.displayName ?? 'No village'),
+              ),
               const SizedBox(height: 20),
               if (!viewModel.hasCensusAccess)
                 const Text('Census is not available for this account.'),
@@ -118,14 +126,21 @@ class _CensusForm extends StatelessWidget {
           Row(
             children: [
               Expanded(
-                child: Text(
-                  'Draft saved',
-                  style: TextStyle(color: Colors.blueGrey.shade700),
+                child: TestId(
+                  id: 'census.draft_saved_text',
+                  child: Text(
+                    'Draft saved',
+                    style: TextStyle(color: Colors.blueGrey.shade700),
+                  ),
                 ),
               ),
-              TextButton(
-                onPressed: viewModel.discardDraft,
-                child: const Text('Discard'),
+              TestId(
+                id: 'census.discard_draft_button',
+                button: true,
+                child: TextButton(
+                  onPressed: viewModel.discardDraft,
+                  child: const Text('Discard'),
+                ),
               ),
             ],
           ),
@@ -135,31 +150,43 @@ class _CensusForm extends StatelessWidget {
           _SpeciesQuantityRow(item, viewModel),
         if (viewModel.hasErrorForKey('submit')) ...[
           const SizedBox(height: 12),
-          Text(
-            viewModel.error('submit'),
-            style: const TextStyle(color: Colors.red),
+          TestId(
+            id: 'census.submit_error_text',
+            liveRegion: true,
+            child: Text(
+              viewModel.error('submit'),
+              style: const TextStyle(color: Colors.red),
+            ),
           ),
         ],
         if (viewModel.message != null) ...[
           const SizedBox(height: 12),
-          Text(
-            viewModel.message!,
-            style: TextStyle(color: Colors.green.shade700),
+          TestId(
+            id: 'census.status_text',
+            liveRegion: true,
+            child: Text(
+              viewModel.message!,
+              style: TextStyle(color: Colors.green.shade700),
+            ),
           ),
         ],
         const SizedBox(height: 20),
         SizedBox(
           width: double.infinity,
-          child: FlatButton.primary(
-            onPressed:
-                viewModel.busy('submit') ? null : () => viewModel.submit(),
-            child: viewModel.busy('submit')
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(color: Colors.white),
-                  )
-                : Text('Submit census', style: TextStyle(fontSize: 15.sp)),
+          child: TestId(
+            id: 'census.submit_button',
+            button: true,
+            child: FlatButton.primary(
+              onPressed:
+                  viewModel.busy('submit') ? null : () => viewModel.submit(),
+              child: viewModel.busy('submit')
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(color: Colors.white),
+                    )
+                  : Text('Submit census', style: TextStyle(fontSize: 15.sp)),
+            ),
           ),
         ),
       ],
@@ -185,35 +212,44 @@ class _SpeciesQuantityRow extends StatelessWidget {
           Row(
             children: [
               Expanded(
-                child: TextFormField(
-                  key: ValueKey(
-                    'animal-${species.id}-${viewModel.fieldVersion}',
-                  ),
-                  initialValue: viewModel.animalQuantities[species.id] ?? '',
-                  keyboardType: TextInputType.number,
-                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  onChanged: (value) =>
-                      viewModel.setAnimalQuantity(species.id, value),
-                  decoration: const InputDecoration(
-                    labelText: 'Animals',
-                    border: OutlineInputBorder(),
+                child: TestId(
+                  id: 'census.${species.code}.animals_field',
+                  textField: true,
+                  child: TextFormField(
+                    key: ValueKey(
+                      'animal-${species.id}-${viewModel.fieldVersion}',
+                    ),
+                    initialValue: viewModel.animalQuantities[species.id] ?? '',
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    onChanged: (value) =>
+                        viewModel.setAnimalQuantity(species.id, value),
+                    decoration: const InputDecoration(
+                      labelText: 'Animals',
+                      border: OutlineInputBorder(),
+                    ),
                   ),
                 ),
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: TextFormField(
-                  key: ValueKey(
-                    'household-${species.id}-${viewModel.fieldVersion}',
-                  ),
-                  initialValue: viewModel.householdQuantities[species.id] ?? '',
-                  keyboardType: TextInputType.number,
-                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  onChanged: (value) =>
-                      viewModel.setHouseholdQuantity(species.id, value),
-                  decoration: const InputDecoration(
-                    labelText: 'Households',
-                    border: OutlineInputBorder(),
+                child: TestId(
+                  id: 'census.${species.code}.households_field',
+                  textField: true,
+                  child: TextFormField(
+                    key: ValueKey(
+                      'household-${species.id}-${viewModel.fieldVersion}',
+                    ),
+                    initialValue:
+                        viewModel.householdQuantities[species.id] ?? '',
+                    keyboardType: TextInputType.number,
+                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    onChanged: (value) =>
+                        viewModel.setHouseholdQuantity(species.id, value),
+                    decoration: const InputDecoration(
+                      labelText: 'Households',
+                      border: OutlineInputBorder(),
+                    ),
                   ),
                 ),
               ),

--- a/lib/ui/census/census_view_model.dart
+++ b/lib/ui/census/census_view_model.dart
@@ -15,6 +15,9 @@ class CensusViewModel extends BaseViewModel {
   final animalQuantities = <int, String>{};
   final householdQuantities = <int, String>{};
   String? message;
+  String? cacheMessage;
+  VillageCensusDraft? draft;
+  int fieldVersion = 0;
 
   CensusViewModel() {
     init();
@@ -32,6 +35,7 @@ class CensusViewModel extends BaseViewModel {
   Future<void> init() async {
     setBusy(true);
     message = null;
+    cacheMessage = null;
     clearErrors();
 
     if (!hasCensusAccess) {
@@ -39,29 +43,50 @@ class CensusViewModel extends BaseViewModel {
       return;
     }
 
-    try {
-      species = await censusService.fetchActiveSpecies();
-      for (final item in species) {
-        animalQuantities.putIfAbsent(item.id, () => '');
-        householdQuantities.putIfAbsent(item.id, () => '');
-      }
-      latestCensus =
-          await censusService.getLatestVillageCensus(selectedVillage!.id);
-    } catch (e) {
-      setError(e.toString());
+    final readData = await censusService.loadVillageCensus(selectedVillage!.id);
+    species = readData.species;
+    latestCensus = readData.latestCensus;
+    _syncQuantityRows();
+    await _loadDraft();
+
+    if (readData.usedCache) {
+      cacheMessage = 'Showing saved census data. Pull to refresh.';
+    } else if (readData.errorMessage != null) {
+      setError(readData.errorMessage);
     }
 
     setBusy(false);
   }
 
-  void setAnimalQuantity(int speciesId, String value) {
+  Future<void> setAnimalQuantity(int speciesId, String value) async {
     animalQuantities[speciesId] = value.trim();
     _clearSubmitError();
+    await _saveDraft();
+    notifyListeners();
   }
 
-  void setHouseholdQuantity(int speciesId, String value) {
+  Future<void> setHouseholdQuantity(int speciesId, String value) async {
     householdQuantities[speciesId] = value.trim();
     _clearSubmitError();
+    await _saveDraft();
+    notifyListeners();
+  }
+
+  bool get hasDraft => draft?.hasValues ?? false;
+
+  Future<void> discardDraft() async {
+    if (selectedVillage == null) {
+      return;
+    }
+    await censusService.clearDraft(selectedVillage!.id);
+    draft = null;
+    for (final item in species) {
+      animalQuantities[item.id] = '';
+      householdQuantities[item.id] = '';
+    }
+    fieldVersion++;
+    message = 'Draft discarded.';
+    notifyListeners();
   }
 
   Future<VillageCensusSubmitResult?> submit() async {
@@ -95,6 +120,8 @@ class CensusViewModel extends BaseViewModel {
 
     if (result is VillageCensusSubmitSuccess) {
       latestCensus = result.snapshot;
+      await censusService.clearDraft(selectedVillage!.id);
+      draft = null;
       message = 'Census submitted.';
     } else if (result is VillageCensusSubmitValidationFailure) {
       setErrorForObject('submit', result.messages.join(', '));
@@ -104,6 +131,53 @@ class CensusViewModel extends BaseViewModel {
 
     notifyListeners();
     return result;
+  }
+
+  void _syncQuantityRows() {
+    final speciesIds = species.map((item) => item.id).toSet();
+    animalQuantities
+        .removeWhere((speciesId, _) => !speciesIds.contains(speciesId));
+    householdQuantities
+        .removeWhere((speciesId, _) => !speciesIds.contains(speciesId));
+    for (final item in species) {
+      animalQuantities.putIfAbsent(item.id, () => '');
+      householdQuantities.putIfAbsent(item.id, () => '');
+    }
+  }
+
+  Future<void> _loadDraft() async {
+    if (selectedVillage == null) {
+      draft = null;
+      return;
+    }
+    draft = await censusService.getDraft(selectedVillage!.id);
+    if (draft == null) {
+      return;
+    }
+    for (final item in species) {
+      animalQuantities[item.id] = draft!.animalQuantities[item.id] ?? '';
+      householdQuantities[item.id] = draft!.householdQuantities[item.id] ?? '';
+    }
+    fieldVersion++;
+  }
+
+  Future<void> _saveDraft() async {
+    if (selectedVillage == null) {
+      return;
+    }
+    final currentDraft = VillageCensusDraft(
+      villageId: selectedVillage!.id,
+      animalQuantities: Map<int, String>.from(animalQuantities),
+      householdQuantities: Map<int, String>.from(householdQuantities),
+      savedAt: DateTime.now(),
+    );
+    if (currentDraft.hasValues) {
+      draft = currentDraft;
+      await censusService.saveDraft(currentDraft);
+    } else {
+      draft = null;
+      await censusService.clearDraft(selectedVillage!.id);
+    }
   }
 
   List<AnimalCensusFactInput>? _buildFacts() {

--- a/lib/ui/home/home_view.dart
+++ b/lib/ui/home/home_view.dart
@@ -6,6 +6,7 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:podd_app/components/notification_appbar_action.dart';
+import 'package:podd_app/components/test_id.dart';
 import 'package:podd_app/ui/home/consent_view.dart';
 import 'package:podd_app/ui/home/home_view_model.dart';
 import 'package:podd_app/ui/notification/user_message_view.dart';
@@ -100,22 +101,38 @@ class HomeView extends HookWidget {
           BottomNavigationBarItem(
             label:
                 AppLocalizations.of(context)?.incidentsTabTitle ?? 'Incidents',
-            icon: const Icon(Icons.art_track),
+            icon: const TestId(
+              id: 'home.nav.incidents_tab',
+              button: true,
+              child: Icon(Icons.art_track),
+            ),
           ),
           if (viewModel.hasObservationFeature)
             BottomNavigationBarItem(
               label: AppLocalizations.of(context)?.observationsTabTitle ??
                   'Observations',
-              icon: const Icon(Icons.format_list_bulleted),
+              icon: const TestId(
+                id: 'home.nav.observations_tab',
+                button: true,
+                child: Icon(Icons.format_list_bulleted),
+              ),
             ),
           if (viewModel.hasAnimalCensusFeature)
             const BottomNavigationBarItem(
               label: 'Census',
-              icon: Icon(Icons.fact_check_outlined),
+              icon: TestId(
+                id: 'home.nav.census_tab',
+                button: true,
+                child: Icon(Icons.fact_check_outlined),
+              ),
             ),
           BottomNavigationBarItem(
             label: AppLocalizations.of(context)?.profileTabTitle ?? 'Profile',
-            icon: const Icon(Icons.account_circle),
+            icon: const TestId(
+              id: 'home.nav.profile_tab',
+              button: true,
+              child: Icon(Icons.account_circle),
+            ),
           ),
         ];
 

--- a/lib/ui/login/login_view.dart
+++ b/lib/ui/login/login_view.dart
@@ -6,6 +6,7 @@ import 'package:podd_app/app_theme.dart';
 import 'package:podd_app/components/flat_button.dart';
 import 'package:podd_app/components/language_dropdown.dart';
 import 'package:podd_app/components/restart_widget.dart';
+import 'package:podd_app/components/test_id.dart';
 import 'package:podd_app/locator.dart';
 import 'package:podd_app/ui/forgot_password/reset_password_request_view.dart';
 import 'package:podd_app/ui/login/login_view_model.dart';
@@ -84,48 +85,66 @@ class _LoginForm extends StackedHookView<LoginViewModel> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    SizedBox(
-                      width: 150.w,
-                      child: _languageDropdown(viewModel, context),
+                    TestId(
+                      id: 'login.language_dropdown',
+                      button: true,
+                      child: SizedBox(
+                        width: 150.w,
+                        child: _languageDropdown(viewModel, context),
+                      ),
                     ),
                     const SizedBox(height: 10),
                     _tenantDropdown(viewModel, context),
                     const SizedBox(height: 20),
                     ...skipIfDomainNotSelected(viewModel, [
-                      TextField(
-                        controller: username,
-                        textInputAction: TextInputAction.next,
-                        onChanged: viewModel.setUsername,
-                        decoration: InputDecoration(
-                          labelText:
-                              AppLocalizations.of(context)!.usernameLabel,
-                          errorText: viewModel.error("username"),
+                      TestId(
+                        id: 'login.username_field',
+                        textField: true,
+                        child: TextField(
+                          controller: username,
+                          textInputAction: TextInputAction.next,
+                          onChanged: viewModel.setUsername,
+                          decoration: InputDecoration(
+                            labelText:
+                                AppLocalizations.of(context)!.usernameLabel,
+                            errorText: viewModel.error("username"),
+                          ),
                         ),
                       ),
                       const SizedBox(height: 20),
-                      TextField(
-                        controller: password,
-                        textInputAction: TextInputAction.done,
-                        obscureText: viewModel.obscureText,
-                        decoration: InputDecoration(
-                          labelText:
-                              AppLocalizations.of(context)!.passwordLabel,
-                          errorText: viewModel.error("password"),
-                          suffixIcon: IconButton(
-                            onPressed: () {
-                              viewModel.setObscureText(!viewModel.obscureText);
-                            },
-                            hoverColor: Colors.transparent,
-                            icon: viewModel.obscureText
-                                ? const Icon(Icons.visibility)
-                                : const Icon(Icons.visibility_off),
+                      TestId(
+                        id: 'login.password_field',
+                        textField: true,
+                        child: TextField(
+                          controller: password,
+                          textInputAction: TextInputAction.done,
+                          obscureText: viewModel.obscureText,
+                          decoration: InputDecoration(
+                            labelText:
+                                AppLocalizations.of(context)!.passwordLabel,
+                            errorText: viewModel.error("password"),
+                            suffixIcon: TestId(
+                              id: 'login.password_visibility_button',
+                              button: true,
+                              child: IconButton(
+                                tooltip: 'Toggle password visibility',
+                                onPressed: () {
+                                  viewModel
+                                      .setObscureText(!viewModel.obscureText);
+                                },
+                                hoverColor: Colors.transparent,
+                                icon: viewModel.obscureText
+                                    ? const Icon(Icons.visibility)
+                                    : const Icon(Icons.visibility_off),
+                              ),
+                            ),
                           ),
+                          onChanged: viewModel.setPassword,
+                          onSubmitted: (value) {
+                            viewModel.setPassword(value);
+                            viewModel.authenticate();
+                          },
                         ),
-                        onChanged: viewModel.setPassword,
-                        onSubmitted: (value) {
-                          viewModel.setPassword(value);
-                          viewModel.authenticate();
-                        },
                       ),
                       SizedBox(
                         width: double.infinity,
@@ -157,29 +176,38 @@ class _LoginForm extends StackedHookView<LoginViewModel> {
                         ),
                       ),
                       if (viewModel.hasErrorForKey("general"))
-                        Text(
-                          viewModel.error("general"),
-                          style: const TextStyle(
-                            color: Colors.red,
+                        TestId(
+                          id: 'login.general_error_text',
+                          liveRegion: true,
+                          child: Text(
+                            viewModel.error("general"),
+                            style: const TextStyle(
+                              color: Colors.red,
+                            ),
                           ),
                         ),
                       SizedBox(
                         width: double.infinity,
-                        child: FlatButton.primary(
-                          onPressed:
-                              viewModel.isBusy ? null : viewModel.authenticate,
-                          child: viewModel.isBusy
-                              ? const SizedBox(
-                                  height: 20,
-                                  width: 20,
-                                  child: CircularProgressIndicator(
-                                    color: Colors.white,
+                        child: TestId(
+                          id: 'login.submit_button',
+                          button: true,
+                          child: FlatButton.primary(
+                            onPressed: viewModel.isBusy
+                                ? null
+                                : viewModel.authenticate,
+                            child: viewModel.isBusy
+                                ? const SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                      color: Colors.white,
+                                    ),
+                                  )
+                                : Text(
+                                    AppLocalizations.of(context)!.loginButton,
+                                    style: TextStyle(fontSize: 15.sp),
                                   ),
-                                )
-                              : Text(
-                                  AppLocalizations.of(context)!.loginButton,
-                                  style: TextStyle(fontSize: 15.sp),
-                                ),
+                          ),
                         ),
                       ),
                       const SizedBox(height: 20),
@@ -232,37 +260,41 @@ class _LoginForm extends StackedHookView<LoginViewModel> {
   Widget _qrcodeLogin(
     BuildContext context,
   ) {
-    return InkWell(
-      onTap: () async {
-        var error = await Navigator.push<String>(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const QrLoginView(),
-          ),
-        );
-        if (error != null) {
-          if (context.mounted) {
-            showAlert(context, error);
-          }
-        }
-      },
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.qr_code_scanner,
-            color: Theme.of(context).primaryColor,
-            size: 16.w,
-          ),
-          const SizedBox(width: 4),
-          Text(
-            AppLocalizations.of(context)!.qrCodeLoginButton,
-            style: TextStyle(
-              color: Theme.of(context).primaryColor,
-              fontSize: 15.sp,
+    return TestId(
+      id: 'login.qr_button',
+      button: true,
+      child: InkWell(
+        onTap: () async {
+          var error = await Navigator.push<String>(
+            context,
+            MaterialPageRoute(
+              builder: (context) => const QrLoginView(),
             ),
-          ),
-        ],
+          );
+          if (error != null) {
+            if (context.mounted) {
+              showAlert(context, error);
+            }
+          }
+        },
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.qr_code_scanner,
+              color: Theme.of(context).primaryColor,
+              size: 16.w,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              AppLocalizations.of(context)!.qrCodeLoginButton,
+              style: TextStyle(
+                color: Theme.of(context).primaryColor,
+                fontSize: 15.sp,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -292,31 +324,35 @@ class _LoginForm extends StackedHookView<LoginViewModel> {
       );
     }
 
-    return DropdownButtonFormField<String>(
-      isExpanded: true,
-      decoration: InputDecoration(
-        border: InputBorder.none,
-        enabledBorder: UnderlineInputBorder(
-            borderSide: BorderSide(color: Theme.of(context).primaryColor)),
-        labelText: AppLocalizations.of(context)!.serverLabel,
+    return TestId(
+      id: 'login.server_dropdown',
+      button: true,
+      child: DropdownButtonFormField<String>(
+        isExpanded: true,
+        decoration: InputDecoration(
+          border: InputBorder.none,
+          enabledBorder: UnderlineInputBorder(
+              borderSide: BorderSide(color: Theme.of(context).primaryColor)),
+          labelText: AppLocalizations.of(context)!.serverLabel,
+        ),
+        hint: const Text("Server"),
+        initialValue: viewModel.subDomain,
+        onChanged: (String? value) async {
+          if (value == null) {
+            return;
+          }
+          await viewModel.changeServer(value);
+          if (context.mounted) {
+            RestartWidget.restartApp(context);
+          }
+        },
+        items: viewModel.serverOptions
+            .map<DropdownMenuItem<String>>((option) => DropdownMenuItem(
+                  value: option["domain"],
+                  child: Text(option['label'] ?? ""),
+                ))
+            .toList(),
       ),
-      hint: const Text("Server"),
-      initialValue: viewModel.subDomain,
-      onChanged: (String? value) async {
-        if (value == null) {
-          return;
-        }
-        await viewModel.changeServer(value);
-        if (context.mounted) {
-          RestartWidget.restartApp(context);
-        }
-      },
-      items: viewModel.serverOptions
-          .map<DropdownMenuItem<String>>((option) => DropdownMenuItem(
-                value: option["domain"],
-                child: Text(option['label'] ?? ""),
-              ))
-          .toList(),
     );
   }
 

--- a/test/services/census_service_test.dart
+++ b/test/services/census_service_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:logger/logger.dart';
+import 'package:podd_app/locator.dart';
+import 'package:podd_app/models/animal_species.dart';
+import 'package:podd_app/models/village.dart';
+import 'package:podd_app/models/village_census.dart';
+import 'package:podd_app/services/api/census_api.dart';
+import 'package:podd_app/services/census_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NoopLink extends Link {
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) {
+    return const Stream.empty();
+  }
+}
+
+class FakeCensusApi extends CensusApi {
+  List<AnimalSpecies> species;
+  VillageCensusSnapshot? latestCensus;
+  Object? speciesError;
+  Object? latestError;
+
+  FakeCensusApi({
+    this.species = const [],
+    this.latestCensus,
+    this.speciesError,
+    this.latestError,
+  }) : super(
+          () => GraphQLClient(
+            link: NoopLink(),
+            cache: GraphQLCache(),
+          ),
+        );
+
+  @override
+  Future<List<AnimalSpecies>> fetchActiveSpecies() async {
+    if (speciesError != null) {
+      throw speciesError!;
+    }
+    return species;
+  }
+
+  @override
+  Future<VillageCensusSnapshot?> getLatestVillageCensus(int villageId) async {
+    if (latestError != null) {
+      throw latestError!;
+    }
+    return latestCensus;
+  }
+}
+
+void main() {
+  group('CensusService draft and cache', () {
+    setUp(() async {
+      await locator.reset();
+      locator.registerSingleton<Logger>(Logger());
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('saves and restores a per-village draft', () async {
+      final service = CensusService(censusApi: FakeCensusApi());
+      final draft = VillageCensusDraft(
+        villageId: 11,
+        animalQuantities: const {1: '12'},
+        householdQuantities: const {1: '3'},
+        savedAt: DateTime(2026, 5, 7),
+      );
+
+      await service.saveDraft(draft);
+      final restored = await service.getDraft(11);
+
+      expect(restored, isNotNull);
+      expect(restored!.animalQuantities[1], '12');
+      expect(restored.householdQuantities[1], '3');
+
+      await service.clearDraft(11);
+      expect(await service.getDraft(11), isNull);
+    });
+
+    test('falls back to cached read data when refresh fails', () async {
+      final cattle = AnimalSpecies(
+        id: 1,
+        code: 'CATTLE',
+        name: 'Cattle',
+      );
+      final latest = VillageCensusSnapshot(
+        id: 99,
+        village: const Village(id: 11, code: 'V001', name: 'Village One'),
+        censusDate: DateTime(2026, 5, 5),
+        facts: [
+          AnimalCensusFact(
+            species: cattle,
+            animalQuantity: 5,
+            householdQuantity: 2,
+          ),
+        ],
+      );
+
+      final onlineService = CensusService(
+        censusApi: FakeCensusApi(species: [cattle], latestCensus: latest),
+      );
+      await onlineService.loadVillageCensus(11);
+
+      final offlineService = CensusService(
+        censusApi: FakeCensusApi(
+          speciesError: Exception('offline species'),
+          latestError: Exception('offline latest'),
+        ),
+      );
+      final readData = await offlineService.loadVillageCensus(11);
+
+      expect(readData.usedCache, isTrue);
+      expect(readData.species.single.displayName, 'CATTLE - Cattle');
+      expect(readData.latestCensus?.facts.single.animalQuantity, 5);
+    });
+  });
+}

--- a/test/ui/census_view_model_test.dart
+++ b/test/ui/census_view_model_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:podd_app/locator.dart';
+import 'package:podd_app/models/animal_species.dart';
+import 'package:podd_app/models/login_result.dart';
+import 'package:podd_app/models/user_profile.dart';
+import 'package:podd_app/models/village.dart';
+import 'package:podd_app/models/village_census.dart';
+import 'package:podd_app/services/auth_service.dart';
+import 'package:podd_app/services/census_service.dart';
+import 'package:podd_app/ui/census/census_view_model.dart';
+
+class AuthServiceMock extends ChangeNotifier implements IAuthService {
+  @override
+  UserProfile? userProfile;
+
+  @override
+  Village? selectedVillage;
+
+  AuthServiceMock({
+    this.userProfile,
+    this.selectedVillage,
+  });
+
+  @override
+  Future<AuthResult> authenticate(String username, String password) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> fetchProfile() {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool? get isLogin => true;
+
+  @override
+  Future<void> logout() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> requestAccessTokenIfExpired() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> saveTokenAndFetchProfile(AuthSuccess loginSuccess) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> selectVillage(int villageId) {
+    throw UnimplementedError();
+  }
+
+  @override
+  updateAvatarUrl(String avatarUrl) {
+    throw UnimplementedError();
+  }
+
+  @override
+  updateConfirmedConsent() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AuthResult> verifyQrToken(String token) {
+    throw UnimplementedError();
+  }
+}
+
+class CensusServiceMock implements ICensusService {
+  final cattle = const AnimalSpecies(
+    id: 1,
+    code: 'CATTLE',
+    name: 'Cattle',
+  );
+  VillageCensusDraft? draft;
+  bool draftCleared = false;
+
+  @override
+  Future<void> clearDraft(int villageId) async {
+    draft = null;
+    draftCleared = true;
+  }
+
+  @override
+  Future<List<AnimalSpecies>> fetchActiveSpecies() async => [cattle];
+
+  @override
+  Future<VillageCensusDraft?> getDraft(int villageId) async => draft;
+
+  @override
+  Future<VillageCensusSnapshot?> getLatestVillageCensus(int villageId) async {
+    return null;
+  }
+
+  @override
+  Future<VillageCensusReadData> loadVillageCensus(int villageId) async {
+    return VillageCensusReadData(species: [cattle]);
+  }
+
+  @override
+  Future<void> saveDraft(VillageCensusDraft draft) async {
+    this.draft = draft;
+  }
+
+  @override
+  Future<VillageCensusSubmitResult> submitVillageCensusSnapshot({
+    required int villageId,
+    required DateTime censusDate,
+    required List<AnimalCensusFactInput> facts,
+  }) async {
+    return VillageCensusSubmitSuccess(
+      VillageCensusSnapshot(
+        id: 100,
+        censusDate: censusDate,
+        facts: facts
+            .map(
+              (fact) => AnimalCensusFact(
+                species: cattle,
+                animalQuantity: fact.animalQuantity,
+                householdQuantity: fact.householdQuantity,
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('CensusViewModel draft behavior', () {
+    late CensusServiceMock censusService;
+
+    setUp(() async {
+      await locator.reset();
+      const village = Village(id: 11, code: 'V001', name: 'Village One');
+      locator.registerSingleton<IAuthService>(
+        AuthServiceMock(
+          selectedVillage: village,
+          userProfile: UserProfile(
+            id: 1,
+            username: 'reporter',
+            firstName: 'Reporter',
+            lastName: 'One',
+            authorityName: 'Authority',
+            authorityId: 6,
+            features: const ['features.animal_census_enabled'],
+            assignedVillages: const [village],
+          ),
+        ),
+      );
+      censusService = CensusServiceMock();
+      locator.registerSingleton<ICensusService>(censusService);
+    });
+
+    test('restores saved draft quantities', () async {
+      censusService.draft = VillageCensusDraft(
+        villageId: 11,
+        animalQuantities: const {1: '7'},
+        householdQuantities: const {1: '2'},
+        savedAt: DateTime(2026, 5, 7),
+      );
+
+      final model = CensusViewModel();
+      await model.init();
+
+      expect(model.hasDraft, isTrue);
+      expect(model.animalQuantities[1], '7');
+      expect(model.householdQuantities[1], '2');
+    });
+
+    test('saves draft on quantity change and clears after submit', () async {
+      final model = CensusViewModel();
+      await model.init();
+
+      await model.setAnimalQuantity(1, '8');
+      await model.setHouseholdQuantity(1, '3');
+
+      expect(censusService.draft?.animalQuantities[1], '8');
+      expect(censusService.draft?.householdQuantities[1], '3');
+
+      await model.submit();
+
+      expect(censusService.draftCleared, isTrue);
+      expect(model.hasDraft, isFalse);
+      expect(model.latestCensus?.facts.single.animalQuantity, 8);
+    });
+
+    test('discardDraft clears local quantities', () async {
+      censusService.draft = VillageCensusDraft(
+        villageId: 11,
+        animalQuantities: const {1: '4'},
+        householdQuantities: const {1: '1'},
+        savedAt: DateTime(2026, 5, 7),
+      );
+      final model = CensusViewModel();
+      await model.init();
+
+      await model.discardDraft();
+
+      expect(censusService.draftCleared, isTrue);
+      expect(model.hasDraft, isFalse);
+      expect(model.animalQuantities[1], '');
+      expect(model.householdQuantities[1], '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- add SharedPreferences-backed FAO census read cache and per-village draft storage
- restore, save, discard, and clear census drafts in the mobile census flow
- add stable Flutter `Semantics.identifier` test IDs for login, navigation, and census controls
- add repo-local Maestro smoke flow, tenant proxy, and runner for Android emulator validation

## Notes

This PR is stacked on `feature/fao-pending-slices` because the Slice 1 FAO mobile PR is still the base dependency.

## Validation

- `flutter test test/services/census_service_test.dart test/ui/census_view_model_test.dart` -> 5 tests passed
- `flutter test` -> 101 tests passed
- `flutter analyze` -> no issues
- `maestro check-syntax .maestro/fao_census_smoke.yaml` -> OK
- `WARMUP_SECONDS=20 .maestro/run_fao_census_smoke.sh` -> passed on Android emulator `emulator-5554` with Maestro 2.5.1
- `git diff --check` and `git diff --cached --check` -> clean
